### PR TITLE
bugfix; save dimuon pair to the output

### DIFF
--- a/e1039-analysis/SimHits/src/SimAna.cc
+++ b/e1039-analysis/SimHits/src/SimAna.cc
@@ -815,6 +815,9 @@ void SimAna::MakeTree()
   saveTree->Branch("dimuon_x_vtx",  dimuon_x_vtx,  "dimuon_x_vtx[n_dimuons]/F");
   saveTree->Branch("dimuon_y_vtx",  dimuon_y_vtx,  "dimuon_y_vtx[n_dimuons]/F");
   saveTree->Branch("dimuon_z_vtx",  dimuon_z_vtx,  "dimuon_z_vtx[n_dimuons]/F");
+  saveTree->Branch("dimuon_px",     dimuon_px,     "dimuon_px[n_dimuons]/F");
+  saveTree->Branch("dimuon_py",     dimuon_py,     "dimuon_py[n_dimuons]/F");
+  saveTree->Branch("dimuon_pz",     dimuon_pz,     "dimuon_pz[n_dimuons]/F");
   saveTree->Branch("dimuon_pmom_x", dimuon_pmom_x, "dimuon_pmom_x[n_dimuons]/F");
   saveTree->Branch("dimuon_pmom_y", dimuon_pmom_y, "dimuon_pmom_y[n_dimuons]/F");
   saveTree->Branch("dimuon_pmom_z", dimuon_pmom_z, "dimuon_pmom_z[n_dimuons]/F");


### PR DESCRIPTION
to fix a minor bug: currently the dimuon pair momentum is calculated, but not written to the output tree. 

in the current ntuples the dimuon pair momentum can still be calculated from the two daughters, e.g. `dimuon_pmom_x + dimuon_nmom_x` for `dimuon_px`; tested on 20 events and they looked to be equivalent.