### PR TITLE
Write output

### DIFF
--- a/e1039-analysis/SimHits/macro/RecoE1039Sim.C
+++ b/e1039-analysis/SimHits/macro/RecoE1039Sim.C
@@ -36,12 +36,12 @@ using namespace std;
  */
 
 int RecoE1039Sim(
-    std::string out_file = "output.root",
     const int nevent = 200,
 		const int isim = 1,
 		bool is_displaced = true,
 		const bool do_analysis = true,
-		std::string ifile="Brem_2.750000_z500_600_eps_-6.4"
+		std::string ifile="Brem_2.750000_z500_600_eps_-6.4",
+    std::string out_file = "output.root"
 		)
 {
   // input simulation
@@ -363,7 +363,7 @@ int RecoE1039Sim(
     Fun4AllHepMCInputManager *in = new Fun4AllHepMCInputManager("HEPMCIN");
     se->registerInputManager(in);
     stringstream ssin;
-    ssin << "$DIR_CMANTILL/displaced_Aprime_Muons/" << ifile
+    ssin << "$DIR_CMANTILL/../../lhe/displaced_Aprime_Muons/" << ifile
          << ".txt";
     in->fileopen(gSystem->ExpandPathName(ssin.str().c_str()));
     in->Verbosity(verbosity);

--- a/e1039-analysis/SimHits/macro/RecoE1039Sim.C
+++ b/e1039-analysis/SimHits/macro/RecoE1039Sim.C
@@ -35,12 +35,14 @@ using namespace std;
  * for Aprime signal, always run with is_displaced to True
  */
 
-int RecoE1039Sim(const int nevent = 200,
-		 const int isim = 1,
-		 bool is_displaced = true,
-		 const bool do_analysis = true,
-		 std::string ifile="Brem_2.750000_z500_600_eps_-6.4"
-		 )
+int RecoE1039Sim(
+    std::string out_file = "output.root",
+    const int nevent = 200,
+		const int isim = 1,
+		bool is_displaced = true,
+		const bool do_analysis = true,
+		std::string ifile="Brem_2.750000_z500_600_eps_-6.4"
+		)
 {
   // input simulation
   bool do_aprime_muon{false},do_aprime_electron{false},do_gun{false},do_dy{false},do_jpsi{false},do_cosmic{false},do_pion{false};
@@ -178,9 +180,9 @@ int RecoE1039Sim(const int nevent = 200,
   }
   else if(do_gun){ // particle gun
     PHG4SimpleEventGenerator *genp = new PHG4SimpleEventGenerator("MUP");
-    genp->add_particles("mu+", 1);  // mu+
+    //genp->add_particles("mu+", 1);  // mu+
     //genp->add_particles("mu-", 1); // mu-
-    //genp->add_particles("e+", 1); // positron
+    genp->add_particles("e+", 1); // positron
     //genp->add_particles("pi+", 1); // pions
     //genp->add_particles("kaon0L", 1); // k0long
     //genp->add_particles("proton", 1); // protons
@@ -349,7 +351,7 @@ int RecoE1039Sim(const int nevent = 200,
   gSystem->Load("libsim_ana.so");
   SimAna *sim_ana = new SimAna();  
   sim_ana->Verbosity(verbosity);
-  //sim_ana->set_output_filename(Form("ana_%s_%d.root", prefix.Data(), seed));
+  sim_ana->set_out_name(out_file);
   sim_ana->set_legacy_rec_container(legacy_rec_container);
   if(do_analysis){
     se->registerSubsystem(sim_ana);    
@@ -361,7 +363,7 @@ int RecoE1039Sim(const int nevent = 200,
     Fun4AllHepMCInputManager *in = new Fun4AllHepMCInputManager("HEPMCIN");
     se->registerInputManager(in);
     stringstream ssin;
-    ssin << "$DIR_CMANTILL/../../lhe/displaced_Aprime_Muons/" << ifile
+    ssin << "$DIR_CMANTILL/displaced_Aprime_Muons/" << ifile
          << ".txt";
     in->fileopen(gSystem->ExpandPathName(ssin.str().c_str()));
     in->Verbosity(verbosity);

--- a/e1039-analysis/SimHits/macro/RecoE1039Sim.C
+++ b/e1039-analysis/SimHits/macro/RecoE1039Sim.C
@@ -35,14 +35,13 @@ using namespace std;
  * for Aprime signal, always run with is_displaced to True
  */
 
-int RecoE1039Sim(
-    const int nevent = 200,
-		const int isim = 1,
-		bool is_displaced = true,
-		const bool do_analysis = true,
-		std::string ifile="Brem_2.750000_z500_600_eps_-6.4",
-    std::string out_file = "output.root"
-		)
+int RecoE1039Sim(const int nevent = 200,
+                const int isim = 1,
+                bool is_displaced = true,
+                const bool do_analysis = true,
+                std::string ifile="Brem_2.750000_z500_600_eps_-6.4",
+                std::string out_file = "output.root"
+                )
 {
   // input simulation
   bool do_aprime_muon{false},do_aprime_electron{false},do_gun{false},do_dy{false},do_jpsi{false},do_cosmic{false},do_pion{false};
@@ -180,9 +179,9 @@ int RecoE1039Sim(
   }
   else if(do_gun){ // particle gun
     PHG4SimpleEventGenerator *genp = new PHG4SimpleEventGenerator("MUP");
-    //genp->add_particles("mu+", 1);  // mu+
+    genp->add_particles("mu+", 1);  // mu+
     //genp->add_particles("mu-", 1); // mu-
-    genp->add_particles("e+", 1); // positron
+    //genp->add_particles("e+", 1); // positron
     //genp->add_particles("pi+", 1); // pions
     //genp->add_particles("kaon0L", 1); // k0long
     //genp->add_particles("proton", 1); // protons

--- a/e1039-analysis/SimHits/src/SimAna.cc
+++ b/e1039-analysis/SimHits/src/SimAna.cc
@@ -726,7 +726,7 @@ int SimAna::GetNodes(PHCompositeNode* topNode)
 
 void SimAna::MakeTree()
 {
-  saveFile= new TFile("output.root", "RECREATE");
+  saveFile= new TFile(saveNameOut, "RECREATE");
   saveTree = new TTree("Events", "Tree Created by SimAna");
   saveTree->Branch("eventID", &eventID, "eventID/I");
 

--- a/e1039-analysis/SimHits/src/SimAna.h
+++ b/e1039-analysis/SimHits/src/SimAna.h
@@ -39,7 +39,7 @@ public:
   int  FindCommonHitIDs(std::vector<int>& hitidvec1, std::vector<int>& hitidvec2);
   SRecTrack* FindBestMomRecTrack(SRecEvent *recEvent, const float true_P); 
 
-  void set_out_name(const char *outName) { saveNameOut = outName; }
+  void set_out_name(std::string out_file) {saveNameOut = out_file.c_str();}
   void set_legacy_rec_container(bool b); 
 
 private:


### PR DESCRIPTION
Allows to specify output file paths. Very useful when submitting multiple jobs at the same time on machines that have shared file system (so they don't overwrite a single file).