### PR TITLE
add tracking information to 2017(?) data 

### DIFF
--- a/e1039-analysis/DataHits/macro/AnaModule/AnaModule.cxx
+++ b/e1039-analysis/DataHits/macro/AnaModule/AnaModule.cxx
@@ -4,6 +4,7 @@
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/getClass.h>
+#include <ktracker/SRecEvent.h>
 
 #include "AnaModule.h"
 
@@ -24,6 +25,7 @@ int AnaModule::InitRun(PHCompositeNode* topNode)
 
 int AnaModule::process_event(PHCompositeNode* topNode)
 {
+  ResetEvalVars();
 
   nHits = rawEvent->getNHitsAll();
 
@@ -32,29 +34,89 @@ int AnaModule::process_event(PHCompositeNode* topNode)
   int nim3TriggerMask = 128;  
 
   for(Int_t k = 0; k < rawEvent->getNHitsAll(); ++k)
-    {
-      Hit h = rawEvent->getHit(k);
-      detectorID[k] = h.detectorID; 
-      elementID[k] = h.elementID;
-      pos[k] = h.pos;
-         
-      // detector ID refers to the detector number as seen here:
-      // st1-drift chambers| D0: 1-6, D1: 7-12
-      // st2-drift chambers| D2: 13-18
-      // st3-drift chambers| D3p: 19-24, D3m: 25-30
-      // h1-hodoscope: H1B/T: 31/22 H1L/R: 33/34
-      // h2-hodoscope: H2L/R: 35/36 H2B/T: 37/38
-      // h3-hodoscope: H3B/T: 39/40
-      // h4-hodoscope: H4Y1L/R: 41/42 H4Y2L/R: 43/44 H4B/T: 45/46
-      // proto-tubes: 47-54
-      // dp-stations: DP1:55-58, DP2:59-6 
+  {
+    Hit h = rawEvent->getHit(k);
+    detectorID[k] = h.detectorID; 
+    elementID[k] = h.elementID;
+    pos[k] = h.pos;
+       
+    // detector ID refers to the detector number as seen here:
+    // st1-drift chambers| D0: 1-6, D1: 7-12
+    // st2-drift chambers| D2: 13-18
+    // st3-drift chambers| D3p: 19-24, D3m: 25-30
+    // h1-hodoscope: H1B/T: 31/22 H1L/R: 33/34
+    // h2-hodoscope: H2L/R: 35/36 H2B/T: 37/38
+    // h3-hodoscope: H3B/T: 39/40
+    // h4-hodoscope: H4Y1L/R: 41/42 H4Y2L/R: 43/44 H4B/T: 45/46
+    // proto-tubes: 47-54
+    // dp-stations: DP1:55-58, DP2:59-6 
 
-      // elementID refers to the hodoscope bar or drift chamber channel hit, this is detector dependent but can give us an idea of position
+    // elementID refers to the hodoscope bar or drift chamber channel hit, this is detector dependent but can give us an idea of position
 
-      tdcTime[k] = h.tdcTime;
-      driftDistance[k] = h.driftDistance;
+    tdcTime[k] = h.tdcTime;
+    driftDistance[k] = h.driftDistance;
 
-    }
+  }
+
+  // track related variables
+  n_tracks = recEvent->getNTracks();
+  for (int i = 0; i < n_tracks; ++i ) {
+    SRecTrack* recTrack = &recEvent->getTrack(i);
+    track_charge[i] = recTrack->getCharge();
+    track_nhits[i] = recTrack->getNHits();
+    track_x_target[i] = (recTrack->getTargetPos()).X();
+    track_y_target[i] = (recTrack->getTargetPos()).Y();
+    track_z_target[i] = (recTrack->getTargetPos()).Z();
+    track_px_target[i] = (recTrack->getTargetMom()).Px();
+    track_py_target[i] = (recTrack->getTargetMom()).Py();
+    track_pz_target[i] = (recTrack->getTargetMom()).Pz();
+    track_x_st1[i] = (recTrack->getPositionVecSt1()).X();
+    track_y_st1[i] = (recTrack->getPositionVecSt1()).Y();
+    track_z_st1[i] = (recTrack->getPositionVecSt1()).Z();
+    track_px_st1[i] = (recTrack->getMomentumVecSt1()).Px();
+    track_py_st1[i] = (recTrack->getMomentumVecSt1()).Py();
+    track_pz_st1[i] = (recTrack->getMomentumVecSt1()).Pz();
+    track_x_vtx[i] = (recTrack->getVertexPos()).X();
+    track_y_vtx[i] = (recTrack->getVertexPos()).Y();
+    track_z_vtx[i] = (recTrack->getVertexPos()).Z();
+    track_px_vtx[i] = (recTrack->getVertexMom()).X();
+    track_py_vtx[i] = (recTrack->getVertexMom()).Y();
+    track_pz_vtx[i] = (recTrack->getVertexMom()).Z();
+    track_chisq[i] = recTrack->getChisq();
+    track_prob[i] = recTrack->getProb();
+    track_quality[i] = recTrack->getQuality();
+    track_nhits_st1[i] = recTrack->getNHitsInStation(1);
+    track_nhits_st2[i] = recTrack->getNHitsInStation(2);
+    track_nhits_st3[i] = recTrack->getNHitsInStation(3);
+    if (i >= 100)
+        break;
+  }
+
+  // dimuon information
+  n_dimuons = recEvent->getNDimuons();
+  for (int i = 0; i < n_dimuons; ++i) {
+    SRecDimuon* recDimuon = &recEvent->getDimuon(i);
+    dimuon_mass[i] = recDimuon->mass;
+    dimuon_chisq[i] = recDimuon->get_chisq();
+    dimuon_x_vtx[i] = (recDimuon->vtx).X();
+    dimuon_y_vtx[i] = (recDimuon->vtx).Y();
+    dimuon_z_vtx[i] = (recDimuon->vtx).Z();
+    dimuon_px[i] = (recDimuon->get_mom()).X();
+    dimuon_py[i] = (recDimuon->get_mom()).Y();
+    dimuon_pz[i] = (recDimuon->get_mom()).Z();
+    dimuon_pmom_x[i] = (recDimuon->p_pos).Px(); //4-momentum of the muon tracks after vertex fit
+    dimuon_pmom_y[i] = (recDimuon->p_pos).Py();
+    dimuon_pmom_z[i] = (recDimuon->p_pos).Pz();
+    dimuon_nmom_x[i] = (recDimuon->p_neg).Px();
+    dimuon_nmom_y[i] = (recDimuon->p_neg).Py();
+    dimuon_nmom_z[i] = (recDimuon->p_neg).Pz();
+    dimuon_ppos_x[i] = (recDimuon->vtx_pos).X(); // vertex position
+    dimuon_ppos_y[i] = (recDimuon->vtx_pos).Y();
+    dimuon_ppos_z[i] = (recDimuon->vtx_pos).Z();
+    dimuon_npos_x[i] = (recDimuon->vtx_neg).X(); 
+    dimuon_npos_y[i] = (recDimuon->vtx_neg).Y();
+    dimuon_npos_z[i] = (recDimuon->vtx_neg).Z();
+  }
 
   if (rawEvent->getTriggerBits()>0 && (rawEvent->getTriggerBits() & (nim1TriggerMask|nim3TriggerMask) != 0)){
     saveTree->Fill();
@@ -75,23 +137,148 @@ int AnaModule::End(PHCompositeNode* topNode)
 int AnaModule::GetNodes(PHCompositeNode* topNode)
 {
   rawEvent = findNode::getClass<SRawEvent>(topNode, "SRawEvent");
-  if(!rawEvent)
-    {
-      rawEvent = nullptr;
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
+  if(!rawEvent){
+    std::cout << "failed to find SRawEvent, return " << std::endl;
+    rawEvent = nullptr;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  recEvent = findNode::getClass<SRecEvent>(topNode, "SRecEvent");
+  if(!recEvent) {
+    std::cout << "failed to find SRecEvent, return " << std::endl;
+    recEvent = nullptr;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
   return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int AnaModule::ResetEvalVars() {
+  nHits = 0;
+  for(int i=0; i<15000; ++i) {
+    detectorID[i] = std::numeric_limits<int>::max();
+    elementID[i] = std::numeric_limits<int>::max();
+    tdcTime[i] = std::numeric_limits<double>::max();
+    driftDistance[i] = std::numeric_limits<double>::max();
+    pos[i] = std::numeric_limits<double>::max();
+  }
+
+  n_tracks = 0;
+  for(int i=0; i<100; ++i) {
+    track_charge[i]      = std::numeric_limits<int>::max();
+    track_nhits[i]       = std::numeric_limits<int>::max();
+    track_x_target[i]    = std::numeric_limits<float>::max();
+    track_y_target[i]    = std::numeric_limits<float>::max();
+    track_z_target[i]    = std::numeric_limits<float>::max();
+    track_px_target[i]   = std::numeric_limits<float>::max();
+    track_py_target[i]   = std::numeric_limits<float>::max();
+    track_pz_target[i]   = std::numeric_limits<float>::max();
+    track_x_st1[i]       = std::numeric_limits<float>::max();
+    track_y_st1[i]       = std::numeric_limits<float>::max();
+    track_z_st1[i]       = std::numeric_limits<float>::max();
+    track_px_st1[i]      = std::numeric_limits<float>::max();
+    track_py_st1[i]      = std::numeric_limits<float>::max();
+    track_pz_st1[i]      = std::numeric_limits<float>::max();
+    track_x_vtx[i]       = std::numeric_limits<float>::max();
+    track_y_vtx[i]       = std::numeric_limits<float>::max();
+    track_z_vtx[i]       = std::numeric_limits<float>::max();
+    track_px_vtx[i]      = std::numeric_limits<float>::max();
+    track_py_vtx[i]      = std::numeric_limits<float>::max();
+    track_pz_vtx[i]      = std::numeric_limits<float>::max();
+    track_m[i]           = std::numeric_limits<float>::max();
+    track_chisq[i]       = std::numeric_limits<float>::max();
+    track_prob[i]        = std::numeric_limits<float>::max();
+    track_quality[i]     = std::numeric_limits<float>::max();
+    track_nhits_st1[i]   = std::numeric_limits<float>::max();
+    track_nhits_st2[i]   = std::numeric_limits<float>::max();
+    track_nhits_st3[i]   = std::numeric_limits<float>::max();
+  }
+
+  n_dimuons = 0;
+  for(int i=0; i<100; ++i) {
+    dimuon_mass[i]       = std::numeric_limits<float>::max();
+    dimuon_chisq[i]      = std::numeric_limits<float>::max();
+    dimuon_x_vtx[i]      = std::numeric_limits<float>::max();
+    dimuon_y_vtx[i]      = std::numeric_limits<float>::max();
+    dimuon_z_vtx[i]      = std::numeric_limits<float>::max();
+    dimuon_px[i]         = std::numeric_limits<float>::max();
+    dimuon_py[i]         = std::numeric_limits<float>::max();
+    dimuon_pz[i]         = std::numeric_limits<float>::max();
+    dimuon_pmom_x[i]     = std::numeric_limits<float>::max();
+    dimuon_pmom_y[i]     = std::numeric_limits<float>::max();
+    dimuon_pmom_z[i]     = std::numeric_limits<float>::max();
+    dimuon_nmom_x[i]     = std::numeric_limits<float>::max();
+    dimuon_nmom_y[i]     = std::numeric_limits<float>::max();
+    dimuon_nmom_z[i]     = std::numeric_limits<float>::max();
+    dimuon_ppos_x[i]     = std::numeric_limits<float>::max();
+    dimuon_ppos_y[i]     = std::numeric_limits<float>::max();
+    dimuon_ppos_z[i]     = std::numeric_limits<float>::max();
+    dimuon_npos_x[i]     = std::numeric_limits<float>::max();
+    dimuon_npos_y[i]     = std::numeric_limits<float>::max();
+    dimuon_npos_z[i]     = std::numeric_limits<float>::max();
+  }
+
+  return 1;
 }
 
 void AnaModule::MakeTree()
 {
   saveFile = new TFile(saveName, "RECREATE");
 
-  saveTree = new TTree("rawEvents", "Raw Tree Created by AnaModule");
+  saveTree = new TTree("Events", "Tree Created by AnaModule");
   saveTree->Branch("nHits", &nHits);
   saveTree->Branch("detectorID", detectorID, "detectorID[nHits]/I");
   saveTree->Branch("elementID", elementID, "elementID[nHits]/I");
   saveTree->Branch("tdcTime", tdcTime, "tdcTime[nHits]/D");
   saveTree->Branch("driftDistance", driftDistance, "driftDistance[nHits]/D");
   saveTree->Branch("pos", pos, "pos[nHits]/D");
+
+  saveTree->Branch("n_tracks",              &n_tracks,            "n_tracks/I");
+  saveTree->Branch("track_charge",         track_charge,        "track_charge[n_tracks]/I");
+  saveTree->Branch("track_nhits",          track_nhits,         "track_nhits[n_tracks]/I");
+  saveTree->Branch("track_x_target",       track_x_target,      "track_x_target[n_tracks]/F");
+  saveTree->Branch("track_y_target",       track_y_target,      "track_y_target[n_tracks]/F");
+  saveTree->Branch("track_z_target",       track_z_target,      "track_z_target[n_tracks]/F");
+  saveTree->Branch("track_px_target",      track_px_target,     "track_px_target[n_tracks]/F");
+  saveTree->Branch("track_py_target",      track_py_target,     "track_py_target[n_tracks]/F");
+  saveTree->Branch("track_pz_target",      track_pz_target,     "track_pz_target[n_tracks]/F");
+  saveTree->Branch("track_x_st1",          track_x_st1,         "track_x_st1[n_tracks]/F");
+  saveTree->Branch("track_y_st1",          track_y_st1,         "track_y_st1[n_tracks]/F");
+  saveTree->Branch("track_z_st1",          track_z_st1,         "track_z_st1[n_tracks]/F");
+  saveTree->Branch("track_px_st1",         track_px_st1,        "track_px_st1[n_tracks]/F");
+  saveTree->Branch("track_py_st1",         track_py_st1,        "track_py_st1[n_tracks]/F");
+  saveTree->Branch("track_pz_st1",         track_pz_st1,        "track_pz_st1[n_tracks]/F");
+  saveTree->Branch("track_x_vtx",          track_x_vtx,         "track_x_vtx[n_tracks]/F");
+  saveTree->Branch("track_y_vtx",          track_y_vtx,         "track_y_vtx[n_tracks]/F");
+  saveTree->Branch("track_z_vtx",          track_z_vtx,         "track_z_vtx[n_tracks]/F");
+  saveTree->Branch("track_px_vtx",         track_px_vtx,        "track_px_vtx[n_tracks]/F");
+  saveTree->Branch("track_py_vtx",         track_py_vtx,        "track_py_vtx[n_tracks]/F");
+  saveTree->Branch("track_pz_vtx",         track_pz_vtx,        "track_pz_vtx[n_tracks]/F");
+  saveTree->Branch("track_m",              track_m,             "track_m[n_tracks]/F");
+  saveTree->Branch("track_chisq",          track_chisq,         "track_chisq[n_tracks]/F");
+  saveTree->Branch("track_prob",           track_prob,          "track_prob[n_tracks]/F");
+  saveTree->Branch("track_quality",        track_quality,       "track_quality[n_tracks]/F");
+  saveTree->Branch("track_nhits_st1",      track_nhits_st1,     "track_nhits_st1[n_tracks]/I");
+  saveTree->Branch("track_nhits_st2",      track_nhits_st2,     "track_nhits_st2[n_tracks]/I");
+  saveTree->Branch("track_nhits_st3",      track_nhits_st3,     "track_nhits_st3[n_tracks]/I");
+
+  saveTree->Branch("n_dimuons",     &n_dimuons,    "n_dimuons/I");
+  saveTree->Branch("dimuon_mass",   dimuon_mass,   "dimuon_mass[n_dimuons]/F");
+  saveTree->Branch("dimuon_chisq",  dimuon_chisq,  "dimuon_chisq[n_dimuons]/F");
+  saveTree->Branch("dimuon_x_vtx",  dimuon_x_vtx,  "dimuon_x_vtx[n_dimuons]/F");
+  saveTree->Branch("dimuon_y_vtx",  dimuon_y_vtx,  "dimuon_y_vtx[n_dimuons]/F");
+  saveTree->Branch("dimuon_z_vtx",  dimuon_z_vtx,  "dimuon_z_vtx[n_dimuons]/F");
+  saveTree->Branch("dimuon_px",     dimuon_px,     "dimuon_px[n_dimuons]/F");
+  saveTree->Branch("dimuon_py",     dimuon_py,     "dimuon_py[n_dimuons]/F");
+  saveTree->Branch("dimuon_pz",     dimuon_pz,     "dimuon_pz[n_dimuons]/F");
+  saveTree->Branch("dimuon_pmom_x", dimuon_pmom_x, "dimuon_pmom_x[n_dimuons]/F");
+  saveTree->Branch("dimuon_pmom_y", dimuon_pmom_y, "dimuon_pmom_y[n_dimuons]/F");
+  saveTree->Branch("dimuon_pmom_z", dimuon_pmom_z, "dimuon_pmom_z[n_dimuons]/F");
+  saveTree->Branch("dimuon_nmom_x", dimuon_nmom_x, "dimuon_nmom_x[n_dimuons]/F");
+  saveTree->Branch("dimuon_nmom_y", dimuon_nmom_y, "dimuon_nmom_y[n_dimuons]/F");
+  saveTree->Branch("dimuon_nmom_z", dimuon_nmom_z, "dimuon_nmom_z[n_dimuons]/F");
+  saveTree->Branch("dimuon_ppos_x", dimuon_ppos_x, "dimuon_ppos_x[n_dimuons]/F");
+  saveTree->Branch("dimuon_ppos_y", dimuon_ppos_y, "dimuon_ppos_y[n_dimuons]/F");
+  saveTree->Branch("dimuon_ppos_z", dimuon_ppos_z, "dimuon_ppos_z[n_dimuons]/F");
+  saveTree->Branch("dimuon_npos_x", dimuon_npos_x, "dimuon_npos_x[n_dimuons]/F");
+  saveTree->Branch("dimuon_npos_y", dimuon_npos_y, "dimuon_npos_y[n_dimuons]/F");
+  saveTree->Branch("dimuon_npos_z", dimuon_npos_z, "dimuon_npos_z[n_dimuons]/F");
 }

--- a/e1039-analysis/DataHits/macro/AnaModule/AnaModule.h
+++ b/e1039-analysis/DataHits/macro/AnaModule/AnaModule.h
@@ -10,6 +10,8 @@
 class TFile;
 class TTree;
 class SQHitVector;
+class SRecTrack;
+class SRecEvent;
 
 class AnaModule: public SubsysReco 
 {
@@ -26,10 +28,12 @@ public:
 
 private:
   int GetNodes(PHCompositeNode* topNode);
+  int ResetEvalVars();
   void MakeTree();
 
   // Input
   SRawEvent* rawEvent;
+  SRecEvent* recEvent;
 
   // Output
   TString saveName;
@@ -42,6 +46,56 @@ private:
   Int_t detectorID[15000], elementID[15000];
   Double_t tdcTime[15000], driftDistance[15000], pos[15000];
 
+  int n_tracks;
+  int track_charge[100];
+  int track_nhits[100];
+  float track_x_target[100];
+  float track_y_target[100];
+  float track_z_target[100];
+  float track_px_target[100];
+  float track_py_target[100];
+  float track_pz_target[100];
+  float track_x_st1[100];
+  float track_y_st1[100];
+  float track_z_st1[100];
+  float track_px_st1[100];
+  float track_py_st1[100];
+  float track_pz_st1[100];
+  float track_x_vtx[100];
+  float track_y_vtx[100];
+  float track_z_vtx[100];
+  float track_px_vtx[100];
+  float track_py_vtx[100];
+  float track_pz_vtx[100];
+  float track_m[100];
+  float track_chisq[100];
+  float track_prob[100];
+  float track_quality[100];
+  int track_nhits_st1[100];
+  int track_nhits_st2[100];
+  int track_nhits_st3[100];
+
+  int n_dimuons;
+  float dimuon_mass[100];
+  float dimuon_chisq[100];
+  float dimuon_x_vtx[100];
+  float dimuon_y_vtx[100];
+  float dimuon_z_vtx[100];
+  float dimuon_px[100];
+  float dimuon_py[100];
+  float dimuon_pz[100];
+  float dimuon_pmom_x[100];
+  float dimuon_pmom_y[100];
+  float dimuon_pmom_z[100];
+  float dimuon_nmom_x[100];
+  float dimuon_nmom_y[100];
+  float dimuon_nmom_z[100];
+  float dimuon_ppos_x[100];
+  float dimuon_ppos_y[100];
+  float dimuon_ppos_z[100];
+  float dimuon_npos_x[100];
+  float dimuon_npos_y[100];
+  float dimuon_npos_z[100];
 };
 
 #endif

--- a/e1039-analysis/DataHits/macro/RecoE906Data.C
+++ b/e1039-analysis/DataHits/macro/RecoE906Data.C
@@ -14,7 +14,7 @@ This macro takes severl external input files to run:
 3. /pnfs/e906/persistent/users/liuk/darkp/digit/R008/02/83/digit_028300_R008.root is E906 run6 data, can be found at /pnfs/e906/persistent/users/liuk/darkp/digit/R008/02/83/
 */
 
-int RecoE906Data(const int nEvents = 1) //8518)
+int RecoE906Data(const int nEvents = 20) //8518)
 {
   const double FMAGSTR = -1.054;
   const double KMAGSTR = -0.951;
@@ -28,27 +28,33 @@ int RecoE906Data(const int nEvents = 1) //8518)
   // rc->set_CharFlag("Calibration", "$E1039_RESOURCE/alignment/run6/calibration.txt");
   // rc->set_CharFlag("Geometry", "user_liuk_geometry_G8_run5_2");
   // rc->set_CharFlag("MySQLURL", "mysql://e906-db1.fnal.gov:3306");
-  rc->Print();
+  //rc->Print();
 
   Fun4AllServer* se = Fun4AllServer::instance();
-  se->Verbosity(1000);
+  //se->Verbosity(1000);
+  se->Verbosity(0);
   
   GeomSvc::UseDbSvc(true);  //set to true to run E1039 style data
   //GeomSvc::UseDbSvc(false);
   GeomSvc* geom_svc = GeomSvc::instance();
-  geom_svc->printTable();
+  //std::cout << "print geom_svc table " << std::endl;
+  //geom_svc->printTable();
+  //std::cout << "done printing " << std::endl;
 
   SQReco* reco = new SQReco();
-  reco->Verbosity(100);
+  reco->Verbosity(0);
+  reco->set_legacy_rec_container(true);
   reco->set_geom_file_name("geom.root");
-  reco->set_enable_KF(true); //Kalman filter not needed for the track finding, disabling KF saves a lot of initialization time
-  reco->setInputTy(SQReco::E906);    //options are SQReco::E906 and SQReco::E1039
+  //reco->set_enable_KF(true); //Kalman filter not needed for the track finding, disabling KF saves a lot of initialization time
+  reco->setInputTy(SQReco::E1039);    //options are SQReco::E906 and SQReco::E1039
   reco->setFitterTy(SQReco::KFREF);  //not relavant for the track finding
   reco->set_evt_reducer_opt("aoce"); //if not provided, event reducer will be using JobOptsSvc to intialize; to turn off, set it to "none"
   reco->set_enable_eval(true);
   reco->set_eval_file_name("eval.root");
-  //se->registerSubsystem(reco);
+  se->registerSubsystem(reco);
 
+  //analysis module
+  //gSystem->Load("libanamodule.so");
   AnaModule* ana = new AnaModule();
   ana->set_output_filename("ana.root");
   se->registerSubsystem(ana);
@@ -60,17 +66,20 @@ int RecoE906Data(const int nEvents = 1) //8518)
   //double driftdistance = geom_svc->getDriftDistance(detectorID, tdcTime);
 
   Fun4AllSRawEventInputManager* in = new Fun4AllSRawEventInputManager("SRawEventIM");
-  in->Verbosity(100);
+  //in->Verbosity(100);
+  in->Verbosity(0);
   in->set_tree_name("save");
   in->set_branch_name("rawEvent");
+  in->enable_E1039_translation();
   in->fileopen("/pnfs/e906/persistent/users/liuk/darkp/digit/R008/02/83/digit_028300_R008.root");
   se->registerInputManager(in);
 
   Fun4AllDstOutputManager* out = new Fun4AllDstOutputManager("DSTOUT", "result.root");
   se->registerOutputManager(out);
-  out->Verbosity(100);
+  //out->Verbosity(100);
+  out->Verbosity(0);
   out->AddNode("SRawEvent");
-  //out->AddNode("SRecEvent");
+  out->AddNode("SRecEvent");
 
   se->run(nEvents);
   se->End();


### PR DESCRIPTION
this PR adds the tracking information to the data ntuples. Code mostly taken from https://github.com/DarkQuest-FNAL/DarkQuest/blob/master/e1039-analysis/SimHits/src/SimAna.cc

for the longer time we might think about merging the simulation and data ntuple maker together to minimize duplicates? @ngpaladi finds out the function to translate E906 to E1039: https://github.com/E1039-Collaboration/e1039-core/blob/master/packages/reco/ktracker/Fun4AllSRawEventInputManager.h#L37. this allows us to run E1039 reco on E906 data. Would be very useful if we want to make these E906 and E1039 workflows consistent.