### PR TITLE
Using relative path for alignment file.

### DIFF
--- a/e1039-analysis/SimHits/macro/RecoE1039Sim.C
+++ b/e1039-analysis/SimHits/macro/RecoE1039Sim.C
@@ -107,7 +107,7 @@ int RecoE1039Sim(const int nevent = 200,
   rc->set_DoubleFlag("KMAGSTR", KMAGSTR);
   rc->set_CharFlag(
       "AlignmentMille",
-      "$DIR_CMANTILL/macro/align_mille.txt"); // alignment file needed for EMCAL
+      "align_mille.txt"); // alignment file needed for EMCAL
   rc->set_CharFlag("fMagFile",
                    "$E1039_RESOURCE/geometry/magnetic_fields/tab.Fmag");
   rc->set_CharFlag("kMagFile",


### PR DESCRIPTION
Quick fix to load the alignment file (use relative instead of full path because file is already there). 